### PR TITLE
Update to Flyway 9.20.1 and use zulu-openjdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM anapsix/alpine-java
+FROM azul/zulu-openjdk:17-jre-latest
 
-RUN apk add --update curl
-RUN curl -OL https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.0/flyway-commandline-4.0-linux-x64.tar.gz
-RUN tar -xzf flyway-commandline-4.0-linux-x64.tar.gz
-RUN rm flyway-commandline-4.0-linux-x64.tar.gz
-RUN chmod +x flyway-4.0/flyway
+ADD https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 /bin/curl
+RUN chmod 755 /bin/curl
+RUN curl -OLs https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/9.20.1/flyway-commandline-9.20.1-linux-x64.tar.gz
+RUN tar -xzf flyway-commandline-9.20.1-linux-x64.tar.gz
+RUN rm flyway-commandline-9.20.1-linux-x64.tar.gz
+RUN chmod 755 flyway-9.20.1/flyway
 
 VOLUME /sql
 

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,14 +1,14 @@
 if [ -z ${DB_CONNECTION_CHECK+x} ];
-  then 
+  then
     echo "DB_CONNECTION_CHECK is not set. Skipping connection test";
   else
-    until flyway-4.0/flyway validate -url=$DB_URL -user=$DB_USER -password=$DB_PASSWORD;
+    until flyway-9.20.1/flyway validate -url=$DB_URL -user=$DB_USER -password=$DB_PASSWORD;
       do
         echo "DB is unavailable - sleeping";
         sleep 1
-      done 
+      done
       echo "DB is up and running";
 
 fi
 
-flyway-4.0/flyway $FLYWAY_CMD -url=$DB_URL -user=$DB_USER -password=$DB_PASSWORD -locations=filesystem:/sql
+flyway-9.20.1/flyway $FLYWAY_CMD -url=$DB_URL -user=$DB_USER -password=$DB_PASSWORD -locations=filesystem:/sql


### PR DESCRIPTION
Use flyway 9.20.1 (currently the newest one), since Flyway 4 is not able to connect to PostgreSQL 15.

Use azul/zulu-openjdk:17-jre-latest, since runing Flyway 9.20.1 on alpine ends with segmentation fault.